### PR TITLE
Add option to tag DR value to files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.13.3
 chardet>=3.0.4
+mutagen>=


### PR DESCRIPTION
Hello magicgoose, thank you for creating this great little tool, it is definitely an upgrade over [dr14 t.meter](https://github.com/simon-r/dr14_t.meter) which is where I saw this repo mentioned.

These changes add the option to tag the DR value to the scanned audio files, this works for flac, mp3, ogg, opus, m4a, and anything that uses APE tags. But note that your player will need to support extended tags, deadbeef or foobar for example. quod libet has partial support (flac, opus, vorbis, APE formats.)

A dependency has been added for the mutagen library, which is also now used to read metadata (this fixes the bug a I was seeing with ffmpeg not properly reading opus tags)

Understandable if you do not want to merge but its out here if anyone finds this useful.

Todo:

Raise error on Cuesheet or formats with no tagging support (WAV)